### PR TITLE
Open the text-file in UTF-8 mode ...

### DIFF
--- a/Teil_05_Word_Cloud.py
+++ b/Teil_05_Word_Cloud.py
@@ -1,7 +1,7 @@
 from wordcloud import WordCloud, STOPWORDS
 import matplotlib.pyplot as plt
 
-with open("Teil_05_Alice_in_wonderland.txt") as f:
+with open("Teil_05_Alice_in_wonderland.txt", encoding='utf-8') as f:
     text = f.read()
 
 wordcloud = WordCloud(width=1920, height=1200)


### PR DESCRIPTION
... for avoiding problems with charsets ( Windows vs Unix ). 

I tried it with a german songtext using Windows ( typed the text manually using notepad ) and it couldn't properly show ä, ö, ü .,.. reading the file in encoding=utf-8 obviously fixes this issue.